### PR TITLE
Support PHP 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 # Pex SDK for PHP
 
-Go bindings for the [Pex SDK](https://docs.search.pex.com).
+PHP bindings for the [Pex SDK](https://docs.search.pex.com).
 
 ### Installation
 
-You can install the Go language bindings like this:
+You can install the PHP language bindings like this:
 
     # Add the SDK bindings repository to your composer.json
     composer config repositories.repo-name vcs https://github.com/Pexeso/pex-sdk-php

--- a/lib/BaseClient.php
+++ b/lib/BaseClient.php
@@ -6,7 +6,7 @@ class BaseClient extends Fingerprinter
 {
     protected $client;
 
-    public function __construct(SearchType $searchType, string $clientID, string $clientSecret)
+    public function __construct(int $searchType, string $clientID, string $clientSecret)
     {
         $defer = new Defer();
 
@@ -22,7 +22,7 @@ class BaseClient extends Fingerprinter
         $this->client = Lib::get()->Pex_Client_New();
         Error::checkMemory($this->client);
 
-        Lib::get()->Pex_Client_Init($this->client, $searchType->value, $clientID, $clientSecret, $status);
+        Lib::get()->Pex_Client_Init($this->client, $searchType, $clientID, $clientSecret, $status);
         Error::checkStatus($status, function () use ($defer) {
             Lib::get()->Pex_Client_Delete(\FFI::addr($this->client));
             $defer->run();

--- a/lib/FingerprintType.php
+++ b/lib/FingerprintType.php
@@ -2,9 +2,9 @@
 
 namespace Pex;
 
-enum FingerprintType: int
+class FingerprintType
 {
-    case Video  = 1;
-    case Audio  = 2;
-    case Melody = 4;
+    public const Video  = 1;
+    public const Audio  = 2;
+    public const Melody = 4;
 }

--- a/lib/Fingerprinter.php
+++ b/lib/Fingerprinter.php
@@ -61,12 +61,12 @@ class Fingerprinter
     private function convertTypes(array $ftTypes): int
     {
         if (!$ftTypes) {
-            return FingerprintType::Audio->value | FingerprintType::Melody->value;
+            return FingerprintType::Audio | FingerprintType::Melody;
         }
 
         $val = 0;
         foreach ($ftTypes as $t) {
-            $val |= $t->value;
+            $val |= $t;
         }
         return $val;
     }

--- a/lib/Lib.php
+++ b/lib/Lib.php
@@ -41,7 +41,7 @@ class Lib
             \FFI::sizeof($init_status_message)
         );
 
-        if ($init_status_code->cdata != StatusCode::OK->value) {
+        if ($init_status_code->cdata != StatusCode::OK) {
             throw new Error(\FFI::string($init_status_message), $init_status_code->cdata);
         }
     }

--- a/lib/SearchType.php
+++ b/lib/SearchType.php
@@ -2,8 +2,8 @@
 
 namespace Pex;
 
-enum SearchType: int
+class SearchType
 {
-    case PrivateSearch  = 0;
-    case PexSearch = 1;
+    public const PrivateSearch = 0;
+    public const PexSearch = 1;
 }

--- a/lib/StatusCode.php
+++ b/lib/StatusCode.php
@@ -2,18 +2,18 @@
 
 namespace Pex;
 
-enum StatusCode: int
+class StatusCode
 {
-    case OK = 0;
-    case DeadlineExceeded = 1;
-    case PermissionDenied = 2;
-    case Unauthenticated = 3;
-    case NotFound = 4;
-    case InvalidInput = 5;
-    case OutOfMemory = 6;
-    case InternalError = 7;
-    case NotInitialized = 8;
-    case ConnectionError = 9;
-    case LookupFailed = 10;
-    case LookupTimedOut = 11;
+    public const OK = 0;
+    public const DeadlineExceeded = 1;
+    public const PermissionDenied = 2;
+    public const Unauthenticated = 3;
+    public const NotFound = 4;
+    public const InvalidInput = 5;
+    public const OutOfMemory = 6;
+    public const InternalError = 7;
+    public const NotInitialized = 8;
+    public const ConnectionError = 9;
+    public const LookupFailed = 10;
+    public const LookupTimedOut = 11;
 }


### PR DESCRIPTION
Enums were added in 8.1 so the bindings were incompatible with 8.0. By replacing them with class consts we keep the same functionality but are a bit more lenient with the PHP version support.