### PR TITLE
Added Error->isRetryable() and ResourceExhausted

### DIFF
--- a/lib/Error.php
+++ b/lib/Error.php
@@ -4,6 +4,8 @@ namespace Pex;
 
 class Error extends \Exception
 {
+    private bool $retryable;
+
     public static function checkMemory($var, callable $cleanup = null): void
     {
         if (!$var) {
@@ -24,7 +26,14 @@ class Error extends \Exception
             $status_code = Lib::get()->Pex_Status_GetCode($status);
             $status_message = Lib::get()->Pex_Status_GetMessage($status);
 
-            throw new Error($status_message, $status_code);
+            $err = new Error($status_message, $status_code);
+            $err->retryable = Lib::get()->Pex_Status_IsRetryable($status);
+            throw $err;
         }
+    }
+
+    public function isRetryable(): bool
+    {
+        return $this->retryable;
     }
 }

--- a/lib/Lib.php
+++ b/lib/Lib.php
@@ -3,7 +3,7 @@
 namespace Pex;
 
 const PEX_SDK_MAJOR_VERSION = 4;
-const PEX_SDK_MINOR_VERSION = 4;
+const PEX_SDK_MINOR_VERSION = 5;
 
 class Lib
 {
@@ -67,6 +67,7 @@ void Pex_Status_Delete(Pex_Status **);
 bool Pex_Status_OK(const Pex_Status *status);
 int Pex_Status_GetCode(const Pex_Status *status);
 const char *Pex_Status_GetMessage(const Pex_Status *status);
+bool Pex_Status_IsRetryable(const Pex_Status *status);
 
 // ----------------------------------------------------------------------------
 

--- a/lib/StatusCode.php
+++ b/lib/StatusCode.php
@@ -16,4 +16,5 @@ class StatusCode
     public const ConnectionError = 9;
     public const LookupFailed = 10;
     public const LookupTimedOut = 11;
+    public const ResourceExhausted = 12;
 }


### PR DESCRIPTION
The `Error->isRetryable()` will tell the user whether retrying this error might resolve the issue.

ResourceExhausted error will be retruned when a user sends more requests that is allowed by their quota.