### PR TITLE
Do not call Lib::close()

### DIFF
--- a/lib/BaseClient.php
+++ b/lib/BaseClient.php
@@ -36,8 +36,6 @@ class BaseClient extends Fingerprinter
         Lib::get()->Pex_Client_Init($this->client, $searchType, $clientID, $clientSecret, $status);
         Error::checkStatus($status, function () use ($defer) {
             Lib::get()->Pex_Client_Delete(\FFI::addr($this->client));
-            $defer->run();
-            Lib::close();
         });
     }
 


### PR DESCRIPTION
The `close()` function is not defined and we also don't want to unload the FFI library so we just get rid of the `Lib::close()` call and everything should be okay. Also, since we're not closing the Lib, we don't need to run the defer explicitly.