### PR TITLE
Fix 'Undefined variable $ft' bug

### DIFF
--- a/lib/BaseClient.php
+++ b/lib/BaseClient.php
@@ -75,6 +75,7 @@ class BaseClient extends Fingerprinter
             Error::checkMemory($buffer);
             $defer->add(fn () => Lib::get()->Pex_Buffer_Delete(\FFI::addr($buffer)));
 
+            $ft = $req->getFingerprint();
             Lib::get()->Pex_Buffer_Set($buffer, $ft->getBytes(), strlen($ft->getBytes()));
 
             Lib::get()->Pex_StartSearchRequest_SetFingerprint($startReq, $buffer, $status);


### PR DESCRIPTION
Commit 9b444cb323821306d46ea34d2be65b942e7c07a2 introduced a `Undefined variable $ft` bug when `$req instanceof ISRCSearchRequest` is `false`.
This change should fix that.